### PR TITLE
Avoid `rec`, update deps sha

### DIFF
--- a/src/main/g8/default.nix
+++ b/src/main/g8/default.nix
@@ -18,10 +18,7 @@ sbt.mkDerivation {
   inherit pname;
   version = "1.0.0";
 
-  depsSha256 =
-    if builtins.currentSystem == "x86_64-linux" then "1wdpa8nws65yy71s8p6h5f4brf0hk32b7dwvl176f4pkc8a1afk4"
-    else if builtins.currentSystem == "x86_64-darwin" then "16zali9b9qhpi7kv69dwflbyiw6z6l0f66n5q3zk76c6rnrzqzy9"
-    else throw "Unsupported system";
+  depsSha256 = "16zali9b9qhpi7kv69dwflbyiw6z6l0f66n5q3zk76c6rnrzqzy9";
 
   depsWarmupCommand = ''
     sbt compile

--- a/src/main/g8/default.nix
+++ b/src/main/g8/default.nix
@@ -1,6 +1,7 @@
 { jdk ? "jdk11_headless" }:
 
 let
+  pname = "sbt-nix-$name$";
   pinned = import nix/pinned.nix;
   config = import nix/config.nix { inherit jdk; };
   sbtix  = import pinned.sbt-derivation;
@@ -13,11 +14,14 @@ let
   inherit (pkgs) sbt makeWrapper;
   inherit (pkgs.lib) escapeShellArg sourceByRegex;
 in
-sbt.mkDerivation rec {
-  pname = "sbt-nix-$name$";
+sbt.mkDerivation {
+  inherit pname;
   version = "1.0.0";
 
-  depsSha256 = "1wdpa8nws65yy71s8p6h5f4brf0hk32b7dwvl176f4pkc8a1afk4";
+  depsSha256 =
+    if builtins.currentSystem == "x86_64-linux" then "1wdpa8nws65yy71s8p6h5f4brf0hk32b7dwvl176f4pkc8a1afk4"
+    else if builtins.currentSystem == "x86_64-darwin" then "16zali9b9qhpi7kv69dwflbyiw6z6l0f66n5q3zk76c6rnrzqzy9"
+    else throw "Unsupported system";
 
   depsWarmupCommand = ''
     sbt compile


### PR DESCRIPTION
`rec` is generally an antipattern, especially if it's only used for one attribute.

Also, the output of the dependency warmup is different on Mac, probably because the input `sbt` derivation is different and might produce some platform-specific code in the output path. I guess we could look into what the actual difference is, and see if this is inherent to the problem or can be fixed upstream in sbt-derivation.